### PR TITLE
fix: reorganize reports into per-run timestamped directories

### DIFF
--- a/packages/cli/src/runner/runnerUtil.ts
+++ b/packages/cli/src/runner/runnerUtil.ts
@@ -56,13 +56,14 @@ export function resolveReporters(fileConfig: EvaliphyConfig): EvaliphyReporter[]
     const jsonAccumulator = new JsonAccumulator({
         onComplete: async (report) => {
             const baseDir = fileConfig.configFile ? path.dirname(fileConfig.configFile) : process.cwd();
-            const reportDir = path.join(baseDir, 'report');
-            await fs.mkdir(reportDir, { recursive: true });
-            const reportPath = path.join(reportDir, `report-${report.meta.runId}.json`);
+            const ts = report.meta.timestamp.replace(/[:.]/g, '-');
+            const runDir = path.join(baseDir, 'reports', `run-${ts}`);
+            await fs.mkdir(runDir, { recursive: true });
+            const reportPath = path.join(runDir, 'results.json');
             await fs.writeFile(reportPath, JSON.stringify(report, null, 2));
 
             // Generate HTML report
-            HtmlWriter.write(report, reportDir);
+            HtmlWriter.write(report, runDir);
         }
     });
     jsonAccumulator.attach();

--- a/packages/reporters/src/console/index.ts
+++ b/packages/reporters/src/console/index.ts
@@ -24,6 +24,7 @@ export class ConsoleReporter implements EvaliphyReporter {
   name = 'console-reporter';
   private options: Required<ConsoleReporterOptions>;
   private startTime: number = 0;
+  private runTimestamp: string = '';
   private failures: TestFailPayload[] = [];
   private spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   private spinnerIndex = 0;
@@ -69,6 +70,7 @@ export class ConsoleReporter implements EvaliphyReporter {
 
   onRunStart(payload: RunStartPayload) {
     this.startTime = Date.now();
+    this.runTimestamp = new Date().toISOString();
     this.failures = [];
     
     console.log(`\n ${pc.cyan(pc.bold('evaliphy'))} ${pc.dim('v1.0.0')}`);
@@ -150,7 +152,7 @@ export class ConsoleReporter implements EvaliphyReporter {
       pc.bold('Tests:       ') + (payload.failed > 0 ? pc.red(`${payload.failed} failed`) + pc.dim(', ') : '') + pc.green(`${payload.passed} passed`) + pc.dim(`, ${total} total`),
       pc.bold('Time:        ') + pc.white(duration),
       pc.bold('Run ID:      ') + pc.dim(payload.runId),
-      pc.bold('HTML Report: ') + pc.dim('report/report-' + payload.runId + '.html')
+      pc.bold('HTML Report: ') + pc.dim('reports/run-' + this.runTimestamp.replace(/[:.]/g, '-') + '/report.html')
     ];
 
     summary.forEach(line => console.log(` ${line}`));

--- a/packages/reporters/src/html/HtmlWriter.ts
+++ b/packages/reporters/src/html/HtmlWriter.ts
@@ -6,7 +6,7 @@ import { PageRenderer } from './renderer/PageRenderer.js';
 export class HtmlWriter {
   static write(report: RunReport, outputDir: string): string {
     const html = PageRenderer.render(report);
-    const fileName = `report-${report.meta.runId}.html`;
+    const fileName = 'report.html';
     const outputPath = path.join(outputDir, fileName);
 
     if (!fs.existsSync(outputDir)) {

--- a/packages/reporters/tests/HtmlReporter.test.ts
+++ b/packages/reporters/tests/HtmlReporter.test.ts
@@ -35,7 +35,7 @@ describe('HtmlWriter', () => {
     const outputPath = HtmlWriter.write(reportFixture as any, outputDir);
 
     expect(fs.writeFileSync).toHaveBeenCalled();
-    expect(outputPath).toContain(`report-${reportFixture.meta.runId}.html`);
+    expect(outputPath).toContain('report.html');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #11

Reorganizes report output from a flat `/report/` directory into a structured per-run layout:

**Before:**
```
report/
  report-<runId>.json
  report-<runId>.html
```

**After:**
```
reports/
  run-<timestamp>/
    results.json
    report.html
```

## Changes

- **`packages/cli/src/runner/runnerUtil.ts`**: Derive a `run-<timestamp>` subdirectory from `report.meta.timestamp` (colons/dots replaced with hyphens for filesystem safety), write `results.json` instead of `report-<runId>.json`
- **`packages/reporters/src/html/HtmlWriter.ts`**: Use fixed filename `report.html` instead of `report-<runId>.html` — the run directory already scopes it uniquely
- **`packages/reporters/tests/HtmlReporter.test.ts`**: Update filename assertion to match new `report.html` name

## Test plan

- [ ] Run `evaliphy eval` — confirm output appears at `reports/run-<timestamp>/results.json` and `reports/run-<timestamp>/report.html`
- [ ] Run multiple evals — confirm each run gets its own timestamped subdirectory with no collisions
- [ ] Unit tests pass: `vitest run` in `packages/reporters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)