### PR TITLE
fix(reporters): improve HTML report assertions section UX

### DIFF
--- a/packages/reporters/src/html/assets/styles.ts
+++ b/packages/reporters/src/html/assets/styles.ts
@@ -186,20 +186,124 @@ tr.expandable {
   overflow-y: auto;
 }
 
-.assertion-list {
-  margin-top: 1rem;
+.assertions-section {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
 }
 
-.assertion-item {
+.assertion-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.assertion-card {
+  background: var(--card-bg);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+}
+
+.assertion-card.passed {
+  border-left: 4px solid var(--success-color);
+}
+
+.assertion-card.failed {
+  border-left: 4px solid var(--failure-color);
+}
+
+.assertion-card-header {
   display: flex;
   justify-content: space-between;
-  padding: 0.5rem 0;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 0, 0, 0.02);
   border-bottom: 1px solid var(--border-color);
 }
 
-.assertion-reason {
-  font-size: 0.8125rem;
+.assertion-card-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.assertion-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-color);
+}
+
+.assertion-score {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.assertion-score-label {
+  font-size: 0.7rem;
   color: var(--gray-color);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.assertion-score-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.assertion-threshold-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 0.625rem 1rem;
+  background: rgba(0, 0, 0, 0.015);
+}
+
+.assertion-threshold-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.assertion-meta-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--gray-color);
+  font-weight: 600;
+}
+
+.assertion-meta-value {
+  font-size: 0.875rem;
+  color: var(--text-color);
+}
+
+.assertion-reasoning {
+  padding: 0.75rem 1rem;
+}
+
+.assertion-reason {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--text-color);
   margin-top: 0.25rem;
+}
+
+.assertion-card-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--gray-color);
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.assertion-card-footer code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  color: var(--text-color);
 }
 `;

--- a/packages/reporters/src/html/renderer/FailureDetail.ts
+++ b/packages/reporters/src/html/renderer/FailureDetail.ts
@@ -12,56 +12,59 @@ export class FailureDetail {
           <div>
             <div class="detail-section-title">Query</div>
             <div class="detail-box">${this.escapeHtml(result.inputs.query || '')}</div>
-            
+
             <div class="detail-section-title" style="margin-top: 1rem;">Context</div>
             <div class="detail-box">${this.escapeHtml(result.inputs.context || '')}</div>
           </div>
           <div>
             <div class="detail-section-title">Response</div>
             <div class="detail-box">${this.escapeHtml(result.inputs.response || '')}</div>
-            
-            <div class="detail-section-title" style="margin-top: 1rem;">Assertions</div>
+          </div>
+        </div>
+        ${assertions.length > 0 ? `
+          <div class="assertions-section">
+            <div class="detail-section-title">Assertions (${assertions.length})</div>
             <div class="assertion-list">
               ${assertions.map(([name, data]) => `
-                <div class="assertion-item ${data.passed ? 'passed' : 'failed'}" style="border-left: 4px solid ${data.passed ? 'var(--success-color)' : 'var(--failure-color)'}; padding: 12px; margin-bottom: 16px; background: var(--bg-color); border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
-                  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-                    <div style="display: flex; align-items: center; gap: 12px;">
-                      <span style="font-weight: 700; font-size: 1.1rem; color: var(--text-color);">${name}</span>
-                      <span class="status-badge status-${data.passed ? 'passed' : 'failed'}" style="font-size: 0.75rem; padding: 2px 8px; border-radius: 12px;">
+                <div class="assertion-card ${data.passed ? 'passed' : 'failed'}">
+                  <div class="assertion-card-header">
+                    <div class="assertion-card-name">
+                      <span class="assertion-name">${name}</span>
+                      <span class="status-badge status-${data.passed ? 'passed' : 'failed'}">
                         ${data.passed ? 'PASSED' : 'FAILED'}
                       </span>
                     </div>
-                    <div style="text-align: right;">
-                      <div style="font-size: 0.85rem; color: var(--gray-color); margin-bottom: 2px;">Score</div>
-                      <div style="font-size: 1.5rem; color: ${getScoreColor(data.score)}; font-weight: 800; line-height: 1;">${formatScore(data.score)}</div>
-                    </div>
-                  </div>
-                  
-                  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 12px; padding: 10px; background: rgba(0,0,0,0.02); border-radius: 4px;">
-                    <div>
-                      <div style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-color); margin-bottom: 4px; font-weight: 600;">Expected</div>
-                      <div style="font-size: 0.9rem; color: var(--text-color);">Score &ge; ${data.threshold ?? '0.7'}</div>
-                    </div>
-                    <div>
-                      <div style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-color); margin-bottom: 4px; font-weight: 600;">Actual</div>
-                      <div style="font-size: 0.9rem; color: ${getScoreColor(data.score)}; font-weight: 600;">${formatScore(data.score)}</div>
+                    <div class="assertion-score">
+                      <div class="assertion-score-label">Score</div>
+                      <div class="assertion-score-value" style="color: ${getScoreColor(data.score)};">${formatScore(data.score)}</div>
                     </div>
                   </div>
 
-                  <div style="margin-bottom: 12px;">
-                    <div style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-color); margin-bottom: 4px; font-weight: 600;">Judge Reasoning</div>
-                    <div class="assertion-reason" style="font-size: 0.9rem; line-height: 1.5; color: var(--text-color);">${this.escapeHtml(data.reason || 'No reasoning provided.')}</div>
+                  <div class="assertion-threshold-row">
+                    <div class="assertion-threshold-cell">
+                      <div class="assertion-meta-label">Expected</div>
+                      <div class="assertion-meta-value">Score &ge; ${data.threshold ?? '0.7'}</div>
+                    </div>
+                    <div class="assertion-threshold-cell">
+                      <div class="assertion-meta-label">Actual</div>
+                      <div class="assertion-meta-value" style="color: ${getScoreColor(data.score)}; font-weight: 600;">${formatScore(data.score)}</div>
+                    </div>
                   </div>
 
-                  <div style="font-size: 0.75rem; color: var(--gray-color); padding-top: 8px; border-top: 1px solid var(--border-color); display: flex; justify-content: space-between;">
-                    <span>Model: <span style="font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; color: var(--text-color);">${data.model || 'unknown'}</span></span>
+                  <div class="assertion-reasoning">
+                    <div class="assertion-meta-label">Judge Reasoning</div>
+                    <div class="assertion-reason">${this.escapeHtml(data.reason || 'No reasoning provided.')}</div>
+                  </div>
+
+                  <div class="assertion-card-footer">
+                    <span>Model: <code>${data.model || 'unknown'}</code></span>
                     ${data.durationMs ? `<span>Duration: ${data.durationMs}ms</span>` : ''}
                   </div>
                 </div>
               `).join('')}
             </div>
           </div>
-        </div>
+        ` : ''}
         ${result.error ? `
           <div style="margin-top: 1rem;">
             <div class="detail-section-title">Error Stack</div>


### PR DESCRIPTION
## Summary

Fixes the overlap and whitespace issues in the HTML report assertions section (issue #14).

**Root cause:** Assertions were rendered inside the right column of the 2-column `detail-grid` alongside the Response box. With multiple assertions, they got squeezed into 50% width causing overlap and poor readability.

**Changes:**
- Move assertions out of the `detail-grid` into a dedicated **full-width section** below the Query/Context/Response grid
- Replace the old flex-row `.assertion-item` with a proper card layout (`.assertion-card`) using CSS Grid `auto-fill` columns — assertions wrap into columns based on available width (min 340px each)
- Extract all inline styles from `FailureDetail.ts` into named CSS classes in `styles.ts` for maintainability
- Add assertion count to section title: "Assertions (N)"

## Test plan

- [ ] Run `npx evaliphy eval` with a config that has multiple assertions
- [ ] Verify assertions section appears below the Query/Context/Response grid (full width)
- [ ] Verify assertion cards display without overlap at various viewport widths
- [ ] Verify passed cards have green left border, failed cards have red left border
- [ ] Verify score, threshold, reasoning, model, and duration all display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)