### PR TITLE
fix(cli): stop double-registering JsonAccumulator handlers

### DIFF
--- a/packages/cli/src/runner/runnerUtil.ts
+++ b/packages/cli/src/runner/runnerUtil.ts
@@ -65,7 +65,11 @@ export function resolveReporters(fileConfig: EvaliphyConfig): EvaliphyReporter[]
             HtmlWriter.write(report, reportDir);
         }
     });
-    jsonAccumulator.attach();
+    // NOTE: do NOT call jsonAccumulator.attach() here. registerReporters() below
+    // subscribes the same onRunStart/onTestPass/onTestFail/onRunEnd handlers via
+    // the generic reporter wiring loop, so calling attach() would double-register
+    // them and each test would be appended to the RunReportBuilder twice -- the
+    // exact "same test appears twice in the HTML report" bug described in #34.
     reporters.push(jsonAccumulator);
 
     for (const reporter of reportersConfig) {


### PR DESCRIPTION
## Summary

`resolveReporters()` was calling `jsonAccumulator.attach()` AND pushing the accumulator into the reporters array the caller passes to `registerReporters()`. `registerReporters()` re-subscribes the same four handlers (`run:start`, `test:pass`, `test:fail`, `run:end`) via its generic wiring loop, so every event fired twice on the same accumulator. Each `test:pass` (and each `test:fail`) then appended the same `RunResult` to the `RunReportBuilder` twice -- and the generated HTML report showed the same test row twice. This is the exact reproduction in #34 (`npx evaliphy eval --config-file=e2e-tests/evaliphy.config.ts`).

## The double-registration

1. `resolveReporters()` (`packages/cli/src/runner/runnerUtil.ts:68`) instantiated the accumulator and called `jsonAccumulator.attach()`. `attach()` does `emitter.on('run:start', ...)`, `emitter.on('test:pass', ...)`, `emitter.on('test:fail', ...)`, `emitter.on('run:end', ...)` -- **subscription round 1**.
2. `resolveReporters()` then `reporters.push(jsonAccumulator)` and returned.
3. The caller passes `reporters` to `registerReporters()` (`runnerUtil.ts:35`), which iterates each reporter and does `emitter.on('test:pass', (p) => reporter.onTestPass!(p))` (plus the same for the other 3 core events + the 5 discovery/test-lifecycle events) -- **subscription round 2**.

Because the emitter now has two listeners pointing at the same `onTestPass` / `onTestFail` method, every test dispatched both of them. `RunReportBuilder.append(result)` ran twice per test, pushing the same `RunResult` into `this.report.results` twice. Downstream, `ResultsTable.render(results)` emitted two `<tr class="main-row">` rows per test in the HTML report.

## Fix

One-line deletion of the `jsonAccumulator.attach()` call. `registerReporters()` is the canonical wiring path -- `ConsoleReporter` and any user-supplied reporters go through it without calling a separate `attach()`, and the accumulator's exported handlers (`onRunStart`, `onTestPass`, `onTestFail`, `onRunEnd`) are already what `registerReporters()` looks for.

A short comment block replaces the removed call so nobody re-adds it thinking it is missing.

```diff
-    jsonAccumulator.attach();
+    // NOTE: do NOT call jsonAccumulator.attach() here. registerReporters() below
+    // subscribes the same onRunStart/onTestPass/onTestFail/onRunEnd handlers via
+    // the generic reporter wiring loop, so calling attach() would double-register
+    // them and each test would be appended to the RunReportBuilder twice -- the
+    // exact "same test appears twice in the HTML report" bug described in #34.
     reporters.push(jsonAccumulator);
```

Follow-up worth considering (not changed here): `JsonAccumulator.attach()` is now effectively dead (no call site). The method could be removed from the public API in a dedicated cleanup PR if the team wants, but I left it in place to keep this PR a pure bugfix with a minimal diff.

## Verification

```
$ pnpm --filter @evaliphy/reporters vitest run
 Test Files  4 passed (4)
      Tests  25 passed (25)

$ pnpm run build
... tsdown ✔ Build complete in 685ms
```

The reporters-package tests exercise the builder and renderer directly (not the emitter wiring), so they continue to pass. The fix applies to the cli package which has no existing unit tests for the wiring path.

Closes #34

---

This contribution was developed with AI assistance (Claude Code).
